### PR TITLE
start camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Cordova plugin that allows camera interaction from Javascript and HTML
 
 **PR's are greatly appreciated.**
 
+# This Fork
+
+Add feature to support open front and back camera simultaneously.
+
 # Features
 
 <ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin id="cordova-plugin-camera-preview" version="0.12.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
 
-   <name>cordova-plugin-camera-preview</name>
+  <name>cordova-plugin-camera-preview</name>
   <description>Cordova plugin that allows camera interaction from HTML code. Show camera preview popup on top of the HTML.</description>
   <license>Apache 2.0</license>
   <keywords>cordova,phonegap,ecosystem:cordova,cordova-android,cordova-ios,android,ios,ionic,camera,cam,camera-preview,preview</keywords>
@@ -17,6 +17,7 @@
     <source-file src="src/android/CameraPreview.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/CameraActivity.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/CustomSurfaceView.java" target-dir="src/com/cordovaplugincamerapreview" />
+    <source-file src="src/android/Camera.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/Preview.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/TapGestureDetector.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/camera_activity.xml" target-dir="res/layout" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
     <source-file src="src/android/CameraPreview.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/CameraActivity.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/CustomSurfaceView.java" target-dir="src/com/cordovaplugincamerapreview" />
-    <source-file src="src/android/Camera.java" target-dir="src/com/cordovaplugincamerapreview" />
+    <source-file src="src/android/CameraFragment.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/Preview.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/TapGestureDetector.java" target-dir="src/com/cordovaplugincamerapreview" />
     <source-file src="src/android/camera_activity.xml" target-dir="res/layout" />

--- a/src/android/Camera.java
+++ b/src/android/Camera.java
@@ -1,0 +1,137 @@
+package com.cordovaplugincamerapreview;
+
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.FrameLayout;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Camera {
+  protected static int nextContainerViewId = ThreadLocalRandom.current().nextInt(20, 100 + 1);
+
+  private CameraActivity fragment;
+  private CallbackContext takePictureCallbackContext;
+  private CallbackContext takeSnapshotCallbackContext;
+  private CallbackContext startRecordVideoCallbackContext;
+  private CallbackContext stopRecordVideoCallbackContext;
+  private CallbackContext setFocusCallbackContext;
+  private CallbackContext startCameraCallbackContext;
+  private CallbackContext tapBackButtonContext;
+
+  private ViewParent webViewParent;
+
+  private int containerViewId;
+
+  public Camera(){
+    containerViewId = nextContainerViewId++;
+  }
+
+  public boolean start (
+    int x, int y, int width, int height,
+    String defaultCamera,
+    Boolean tapToTakePicture, Boolean dragEnabled, Boolean toBack,
+    String alpha,
+    boolean tapFocus, boolean disableExifHeaderStripping, boolean storeToFile,
+    CallbackContext callbackContext
+  ) {
+    fragment = new CameraActivity();
+    fragment.setEventListener(this);
+    fragment.defaultCamera = defaultCamera;
+    fragment.tapToTakePicture = tapToTakePicture;
+    fragment.dragEnabled = dragEnabled;
+    fragment.tapToFocus = tapFocus;
+    fragment.disableExifHeaderStripping = disableExifHeaderStripping;
+    fragment.storeToFile = storeToFile;
+    fragment.toBack = toBack;
+
+    DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
+
+    // offset
+    int computedX = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, x, metrics);
+    int computedY = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, y, metrics);
+
+    // size
+    int computedWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, width, metrics);
+    int computedHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, height, metrics);
+
+    fragment.setRect(computedX, computedY, computedWidth, computedHeight);
+
+    startCameraCallbackContext = callbackContext;
+
+    cordova.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+
+        //create or update the layout params for the container view
+        FrameLayout containerView = (FrameLayout)cordova.getActivity().findViewById(containerViewId);
+        if(containerView == null){
+          containerView = new FrameLayout(cordova.getActivity().getApplicationContext());
+          containerView.setId(containerViewId);
+
+          FrameLayout.LayoutParams containerLayoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
+          cordova.getActivity().addContentView(containerView, containerLayoutParams);
+        }
+
+        //display camera below the webview
+        if(toBack){
+          View view = webView.getView();
+          ViewParent rootParent = containerView.getParent();
+          ViewParent curParent = view.getParent();
+
+          view.setBackgroundColor(0x00000000);
+
+          // If parents do not match look for.
+          if(curParent.getParent() != rootParent) {
+            while(curParent != null && curParent.getParent() != rootParent) {
+              curParent = curParent.getParent();
+            }
+
+            if(curParent != null) {
+              ((ViewGroup)curParent).setBackgroundColor(0x00000000);
+              ((ViewGroup)curParent).bringToFront();
+            } else {
+              // Do default...
+              curParent = view.getParent();
+              webViewParent = curParent;
+              ((ViewGroup)view).bringToFront();
+            }
+          }else{
+            // Default
+            webViewParent = curParent;
+            rootParent.bringChildToFront(((View) webViewParent));
+          }
+
+        }else{
+          //set camera back to front
+          final float opacity = Float.parseFloat(alpha);
+          containerView.setAlpha(opacity);
+          containerView.bringToFront();
+        }
+
+        //add the fragment to the container
+        FragmentManager fragmentManager = cordova.getActivity().getFragmentManager();
+        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+        fragmentTransaction.add(containerView.getId(), fragment);
+        fragmentTransaction.commit();
+      }
+    });
+
+    return true;
+  }
+
+  public void onCameraStarted() {
+    Log.d(TAG, "Camera started");
+
+    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "Camera started");
+    pluginResult.setKeepCallback(false);
+    startCameraCallbackContext.sendPluginResult(pluginResult);
+  }
+}

--- a/src/android/CameraFragment.java
+++ b/src/android/CameraFragment.java
@@ -158,6 +158,19 @@ public class CameraFragment implements CameraActivity.CameraPreviewListener {
     return true;
   }
 
+  public boolean stopRecordVideo(CallbackContext callbackContext) {
+    stopRecordVideoCallbackContext = callbackContext;
+
+    cordova.getThreadPool().execute(new Runnable() {
+      @Override
+      public void run() {
+        fragment.stopRecord();
+      }
+    });
+
+    return true;
+  }
+
   private String getFilePath(String filename) {
     String videoFilePath = cordova.getActivity().getCacheDir().toString() + "/";
     String fileName = filename;
@@ -207,7 +220,19 @@ public class CameraFragment implements CameraActivity.CameraPreviewListener {
     startRecordVideoCallbackContext.error(message);
   }
 
-  public void onStopRecordVideo(String file) {};
-  public void onStopRecordVideoError(String error) {};
+  public void onStopRecordVideo(String file) {
+    Log.d(TAG, "onStopRecordVideo success");
+
+    PluginResult result = new PluginResult(PluginResult.Status.OK, file);
+    result.setKeepCallback(true);
+
+    stopRecordVideoCallbackContext.sendPluginResult(result);
+  };
+
+  public void onStopRecordVideoError(String error) {
+    Log.d(TAG, "onStopRecordVideo error");
+
+    stopRecordVideoCallbackContext.error(error);
+  };
   /* ======== Camera activity listeners ======== */
 }

--- a/src/android/CameraFragment.java
+++ b/src/android/CameraFragment.java
@@ -2,6 +2,7 @@ package com.cordovaplugincamerapreview;
 
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+import android.util.Log;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.View;
@@ -10,12 +11,19 @@ import android.view.ViewParent;
 import android.widget.FrameLayout;
 
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.PluginResult;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-public class Camera {
+public class CameraFragment implements CameraActivity.CameraPreviewListener {
   protected static int nextContainerViewId = ThreadLocalRandom.current().nextInt(20, 100 + 1);
+  private static final String TAG = "Camera";
+
+  private CordovaInterface cordova;
+  private CordovaWebView webView;
 
   private CameraActivity fragment;
   private CallbackContext takePictureCallbackContext;
@@ -30,14 +38,16 @@ public class Camera {
 
   private int containerViewId;
 
-  public Camera(){
+  public CameraFragment(CordovaInterface ci, CordovaWebView cwv) {
+    cordova = ci;
+    webView = cwv;
     containerViewId = nextContainerViewId++;
   }
 
   public boolean start (
     int x, int y, int width, int height,
     String defaultCamera,
-    Boolean tapToTakePicture, Boolean dragEnabled, Boolean toBack,
+    Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack,
     String alpha,
     boolean tapFocus, boolean disableExifHeaderStripping, boolean storeToFile,
     CallbackContext callbackContext
@@ -127,11 +137,25 @@ public class Camera {
     return true;
   }
 
+  /* ======== Camera activity listeners ======== */
+  public void onPictureTaken(String originalPicture) {};
+  public void onPictureTakenError(String message) {};
+  public void onSnapshotTaken(String originalPicture) {};
+  public void onSnapshotTakenError(String message) {};
+  public void onFocusSet(int pointX, int pointY) {};
+  public void onFocusSetError(String message) {};
+  public void onBackButton() {};
   public void onCameraStarted() {
     Log.d(TAG, "Camera started");
 
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "Camera started");
     pluginResult.setKeepCallback(false);
     startCameraCallbackContext.sendPluginResult(pluginResult);
-  }
+
+  };
+  public void onStartRecordVideo() {};
+  public void onStartRecordVideoError(String message) {};
+  public void onStopRecordVideo(String file) {};
+  public void onStopRecordVideoError(String error) {};
+  /* ======== Camera activity listeners ======== */
 }

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -317,7 +317,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  public void onCameraStarted() {}
+  public void onCameraStarted() {};
 
   private boolean takeSnapshot(final String cameraDirection, int quality, CallbackContext callbackContext) {
     if(this.hasView(cameraDirection, callbackContext) == false){
@@ -382,41 +382,18 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return getCameraFragment(cameraDirection).startRecordVideo(width, height, quality, withFlash, callbackContext);
   }
 
-  public void onStartRecordVideo() {}
-
-  public void onStartRecordVideoError(String message) {}
+  public void onStartRecordVideo() {};
+  public void onStartRecordVideoError(String message) {};
 
   private boolean stopRecordVideo(final String cameraDirection, CallbackContext callbackContext) {
     if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
-
-    stopRecordVideoCallbackContext = callbackContext;
-
-    cordova.getThreadPool().execute(new Runnable() {
-      @Override
-      public void run() {
-        fragment.stopRecord();
-      }
-    });
-
-    return true;
+    return getCameraFragment(cameraDirection).stopRecordVideo(callbackContext);
   }
 
-  public void onStopRecordVideo(String file) {
-    Log.d(TAG, "onStopRecordVideo success");
-
-    PluginResult result = new PluginResult(PluginResult.Status.OK, file);
-    result.setKeepCallback(true);
-
-    stopRecordVideoCallbackContext.sendPluginResult(result);
-  }
-
-  public void onStopRecordVideoError(String err) {
-    Log.d(TAG, "onStopRecordVideo error");
-
-    stopRecordVideoCallbackContext.error(err);
-  }
+  public void onStopRecordVideo(String file) {};
+  public void onStopRecordVideoError(String err) {};
 
   private boolean setColorEffect(final String cameraDirection, String effect, CallbackContext callbackContext) {
     if(this.hasCamera(cameraDirection, callbackContext) == false){

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -77,8 +77,6 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   private static final int CAM_REQ_CODE = 0;
   private static final int VID_REQ_CODE = 1;
-  private String VIDEO_FILE_PATH = "";
-  private static final String VIDEO_FILE_EXTENSION = ".mp4";
 
   private static final String [] permissions = {
     Manifest.permission.CAMERA
@@ -120,9 +118,9 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
         return true;
       }
     } else if (TAKE_PICTURE_ACTION.equals(action)) {
-      return takePicture(args.getInt(0), args.getInt(1), args.getInt(2), callbackContext);
+      return takePicture(args.getString(0), args.getInt(1), args.getInt(2), args.getInt(3), callbackContext);
     } else if (TAKE_SNAPSHOT_ACTION.equals(action)) {
-      return takeSnapshot(args.getInt(0), callbackContext);
+      return takeSnapshot(args.getString(0), args.getInt(1), callbackContext);
     }else if (START_RECORD_VIDEO_ACTION.equals(action)) {
       String[] videoPermissions = getVideoPermissions();
 
@@ -135,67 +133,67 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
         return true;
       }
     } else if (STOP_RECORD_VIDEO_ACTION.equals(action)) {
-      return stopRecordVideo(callbackContext);
+      return stopRecordVideo(args.getString(0), callbackContext);
     } else if (COLOR_EFFECT_ACTION.equals(action)) {
-      return setColorEffect(args.getString(0), callbackContext);
+      return setColorEffect(args.getString(0), args.getString(1), callbackContext);
     } else if (ZOOM_ACTION.equals(action)) {
-      return setZoom(args.getInt(0), callbackContext);
+      return setZoom(args.getString(0), args.getInt(1), callbackContext);
     } else if (GET_ZOOM_ACTION.equals(action)) {
-      return getZoom(callbackContext);
+      return getZoom(args.getString(0), callbackContext);
     } else if (GET_HFOV_ACTION.equals(action)) {
-      return getHorizontalFOV(callbackContext);
+      return getHorizontalFOV(args.getString(0), callbackContext);
     } else if (GET_MAX_ZOOM_ACTION.equals(action)) {
-      return getMaxZoom(callbackContext);
+      return getMaxZoom(args.getString(0), callbackContext);
     } else if (PREVIEW_SIZE_ACTION.equals(action)) {
-      return setPreviewSize(args.getInt(0), args.getInt(1), callbackContext);
+      return setPreviewSize(args.getString(0), args.getInt(1), args.getInt(2), callbackContext);
     } else if (SUPPORTED_FLASH_MODES_ACTION.equals(action)) {
-      return getSupportedFlashModes(callbackContext);
+      return getSupportedFlashModes(args.getString(0), callbackContext);
     } else if (GET_FLASH_MODE_ACTION.equals(action)) {
-      return getFlashMode(callbackContext);
+      return getFlashMode(args.getString(0), callbackContext);
     } else if (SET_FLASH_MODE_ACTION.equals(action)) {
-      return setFlashMode(args.getString(0), callbackContext);
+      return setFlashMode(args.getString(0), args.getString(1), callbackContext);
     } else if (STOP_CAMERA_ACTION.equals(action)){
-      return stopCamera(callbackContext);
+      return stopCamera(args.getString(0), callbackContext);
     } else if (SHOW_CAMERA_ACTION.equals(action)) {
-      return showCamera(callbackContext);
+      return showCamera(args.getString(0), callbackContext);
     } else if (HIDE_CAMERA_ACTION.equals(action)) {
-      return hideCamera(callbackContext);
+      return hideCamera(args.getString(0), callbackContext);
     } else if (TAP_TO_FOCUS.equals(action)) {
-      return tapToFocus(args.getInt(0), args.getInt(1), callbackContext);
+      return tapToFocus(args.getString(0), args.getInt(1), args.getInt(2), callbackContext);
     } else if (SWITCH_CAMERA_ACTION.equals(action)) {
-      return switchCamera(callbackContext);
+      return switchCamera(args.getString(0), callbackContext);
     } else if (SUPPORTED_PICTURE_SIZES_ACTION.equals(action)) {
-      return getSupportedPictureSizes(callbackContext);
+      return getSupportedPictureSizes(args.getString(0), callbackContext);
     } else if (GET_EXPOSURE_MODES_ACTION.equals(action)) {
-      return getExposureModes(callbackContext);
+      return getExposureModes(args.getString(0), callbackContext);
     } else if (SUPPORTED_FOCUS_MODES_ACTION.equals(action)) {
-      return getSupportedFocusModes(callbackContext);
+      return getSupportedFocusModes(args.getString(0), callbackContext);
     } else if (GET_FOCUS_MODE_ACTION.equals(action)) {
-      return getFocusMode(callbackContext);
+      return getFocusMode(args.getString(0), callbackContext);
     } else if (SET_FOCUS_MODE_ACTION.equals(action)) {
-      return setFocusMode(args.getString(0), callbackContext);
+      return setFocusMode(args.getString(0), args.getString(1), callbackContext);
     } else if (GET_EXPOSURE_MODE_ACTION.equals(action)) {
-      return getExposureMode(callbackContext);
+      return getExposureMode(args.getString(0), callbackContext);
     } else if (SET_EXPOSURE_MODE_ACTION.equals(action)) {
-      return setExposureMode(args.getString(0), callbackContext);
+      return setExposureMode(args.getString(0), args.getString(1), callbackContext);
     } else if (GET_EXPOSURE_COMPENSATION_ACTION.equals(action)) {
-      return getExposureCompensation(callbackContext);
+      return getExposureCompensation(args.getString(0), callbackContext);
     } else if (SET_EXPOSURE_COMPENSATION_ACTION.equals(action)) {
-      return setExposureCompensation(args.getInt(0), callbackContext);
+      return setExposureCompensation(args.getString(0), args.getInt(1), callbackContext);
     } else if (GET_EXPOSURE_COMPENSATION_RANGE_ACTION.equals(action)) {
-      return getExposureCompensationRange(callbackContext);
+      return getExposureCompensationRange(args.getString(0), callbackContext);
     } else if (SUPPORTED_WHITE_BALANCE_MODES_ACTION.equals(action)) {
-      return getSupportedWhiteBalanceModes(callbackContext);
+      return getSupportedWhiteBalanceModes(args.getString(0), callbackContext);
     } else if (GET_WHITE_BALANCE_MODE_ACTION.equals(action)) {
-      return getWhiteBalanceMode(callbackContext);
+      return getWhiteBalanceMode(args.getString(0), callbackContext);
     } else if (SET_WHITE_BALANCE_MODE_ACTION.equals(action)) {
-      return setWhiteBalanceMode(args.getString(0),callbackContext);
+      return setWhiteBalanceMode(args.getString(0), args.getString(1),callbackContext);
     } else if (SET_BACK_BUTTON_CALLBACK.equals(action)) {
       return setBackButtonListener(callbackContext);
     } else if (SUPPORTED_COLOR_EFFECTS_ACTION.equals(action)) {
-      return getSupportedColorEffects(callbackContext);
+      return getSupportedColorEffects(args.getString(0), callbackContext);
     } else if (GET_CAMERA_CHARACTERISTICS_ACTION.equals(action)) {
-      return getCameraCharacteristics(callbackContext);
+      return getCameraCharacteristics(args.getString(0), callbackContext);
     }
 
     return false;
@@ -217,8 +215,20 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
   }
 
-  private boolean hasView(CallbackContext callbackContext) {
-    if(fragment == null) {
+  private CameraFragment getCameraFragment (String cameraDirection) {
+    if (cameraDirection.equals("front")) {
+      return frontCamera;
+    }
+    else if (cameraDirection.equals("back")) {
+      return backCamera;
+    }
+    else {
+      return null;
+    }
+  }
+
+  private boolean hasView(final String cameraDirection, CallbackContext callbackContext) {
+    if(getCameraFragment(cameraDirection).hasView() == false) {
       callbackContext.error("No preview");
       return false;
     }
@@ -226,12 +236,12 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean hasCamera(CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean hasCamera(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return false;
     }
 
-    if(fragment.getCamera() == null) {
+    if(this.getCameraFragment(cameraDirection).getCamera() == null) {
       callbackContext.error("No Camera");
       return false;
     }
@@ -239,8 +249,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getSupportedPictureSizes(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getSupportedPictureSizes(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -270,23 +280,11 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private CameraFragment getCamera (String direction) {
-    if (direction.equals("front")) {
-      return frontCamera;
-    }
-    else if (direction.equals("back")) {
-      return backCamera;
-    }
-    else {
-      throw new IllegalArgumentException("Invalid camera direction '" + direction + "'");
-    }
-  }
-
   private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, boolean disableExifHeaderStripping, boolean storeToFile, CallbackContext callbackContext) {
     Log.d(TAG, "start camera action");
 
     try {
-      if (getCamera(defaultCamera) != null) {
+      if (getCameraFragment(defaultCamera) != null) {
         callbackContext.error(String.format("%s camera already started", defaultCamera));
         return true;
       }
@@ -296,7 +294,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
   
     CameraFragment camera = new CameraFragment(cordova, webView);
-    boolean result = camera.start(
+    boolean result = camera.startCamera(
       x, y, width, height,
       defaultCamera,
       tapToTakePicture, dragEnabled, toBack,
@@ -321,8 +319,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
 
   public void onCameraStarted() {}
 
-  private boolean takeSnapshot(int quality, CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean takeSnapshot(final String cameraDirection, int quality, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -350,8 +348,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     takeSnapshotCallbackContext = null;
   }
 
-  private boolean takePicture(int width, int height, int quality, CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean takePicture(final String cameraDirection, int width, int height, int quality, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
     takePictureCallbackContext = callbackContext;
@@ -377,40 +375,19 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     takePictureCallbackContext.error(message);
   }
 
-  private boolean startRecordVideo(final String camera, final int width, final int height, final int quality, final boolean withFlash, CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean startRecordVideo(final String cameraDirection, final int width, final int height, final int quality, final boolean withFlash, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
-    final String filename = "videoTmp";
-    VIDEO_FILE_PATH = cordova.getActivity().getCacheDir().toString() + "/";
-    startRecordVideoCallbackContext = callbackContext;
-     cordova.getThreadPool().execute(new Runnable() {
-      @Override
-      public void run() {
-        fragment.startRecord(getFilePath(filename), camera, width, height, quality, withFlash);
-      }
-    });
-
-    return true;
+    return getCameraFragment(cameraDirection).startRecordVideo(width, height, quality, withFlash, callbackContext);
   }
 
-  public void onStartRecordVideo() {
-    Log.d(TAG, "onStartRecordVideo started");
+  public void onStartRecordVideo() {}
 
-    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
-    pluginResult.setKeepCallback(true);
+  public void onStartRecordVideoError(String message) {}
 
-    startRecordVideoCallbackContext.sendPluginResult(pluginResult);
-  }
-
-  public void onStartRecordVideoError(String message) {
-    Log.d(TAG, "CameraPreview onStartRecordVideo");
-
-    startRecordVideoCallbackContext.error(message);
-  }
-
-  private boolean stopRecordVideo(CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean stopRecordVideo(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -441,22 +418,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     stopRecordVideoCallbackContext.error(err);
   }
 
-  private String getFilePath(String filename) {
-    String fileName = filename;
-
-    int i = 1;
-
-    while (new File(VIDEO_FILE_PATH + fileName + VIDEO_FILE_EXTENSION).exists()) {
-      // Add number suffix if file exists
-      fileName = filename + '_' + i;
-      i++;
-    }
-
-    return VIDEO_FILE_PATH + fileName + VIDEO_FILE_EXTENSION;
-  }
-
-  private boolean setColorEffect(String effect, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setColorEffect(final String cameraDirection, String effect, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -477,8 +440,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getSupportedColorEffects(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getSupportedColorEffects(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -499,8 +462,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getExposureModes(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getExposureModes(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -519,8 +482,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getExposureMode(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getExposureMode(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -543,8 +506,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setExposureMode(String exposureMode, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setExposureMode(final String cameraDirection, String exposureMode, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -562,8 +525,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getExposureCompensation(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getExposureCompensation(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -580,8 +543,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setExposureCompensation(int exposureCompensation, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setExposureCompensation(final String cameraDirection, int exposureCompensation, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -608,8 +571,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getExposureCompensationRange(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getExposureCompensationRange(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -636,8 +599,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getSupportedWhiteBalanceModes(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getSupportedWhiteBalanceModes(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -661,8 +624,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getWhiteBalanceMode(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getWhiteBalanceMode(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -689,8 +652,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setWhiteBalanceMode(String whiteBalanceMode, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setWhiteBalanceMode(final String cameraDirection, String whiteBalanceMode, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -723,8 +686,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getMaxZoom(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getMaxZoom(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -741,8 +704,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
- private boolean getHorizontalFOV(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+ private boolean getHorizontalFOV(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -756,8 +719,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
   }
 
 
-  private boolean getZoom(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getZoom(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -774,8 +737,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setZoom(int zoom, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setZoom(final String cameraDirection, int zoom, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -794,8 +757,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setPreviewSize(int width, int height, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setPreviewSize(final String cameraDirection, int width, int height, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -810,8 +773,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getSupportedFlashModes(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getSupportedFlashModes(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -831,8 +794,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getSupportedFocusModes(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getSupportedFocusModes(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -855,8 +818,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean getFocusMode(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getFocusMode(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -876,8 +839,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setFocusMode(String focusMode, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setFocusMode(final String cameraDirection, String focusMode, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -898,8 +861,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     }
   }
 
-  private boolean getFlashMode(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getFlashMode(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -917,8 +880,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean setFlashMode(String flashMode, CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean setFlashMode(final String cameraDirection, String flashMode, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -940,7 +903,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean stopCamera(CallbackContext callbackContext) {
+  private boolean stopCamera(final String cameraDirection, CallbackContext callbackContext) {
     if(webViewParent != null) {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
@@ -951,7 +914,7 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
       });
     }
 
-    if(this.hasView(callbackContext) == false){
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -965,8 +928,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean showCamera(CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean showCamera(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -979,8 +942,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean hideCamera(CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean hideCamera(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -993,8 +956,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
-  private boolean tapToFocus(final int pointX, final int pointY, CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean tapToFocus(final String cameraDirection, final int pointX, final int pointY, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -1034,8 +997,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     setFocusCallbackContext.error(message);
   }
 
-  private boolean switchCamera(CallbackContext callbackContext) {
-    if(this.hasView(callbackContext) == false){
+  private boolean switchCamera(String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasView(cameraDirection, callbackContext) == false){
       return true;
     }
 
@@ -1062,8 +1025,8 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     tapBackButtonContext.sendPluginResult(pluginResult);
   }
 
-  private boolean getCameraCharacteristics(CallbackContext callbackContext) {
-    if(this.hasCamera(callbackContext) == false){
+  private boolean getCameraCharacteristics(final String cameraDirection, CallbackContext callbackContext) {
+    if(this.hasCamera(cameraDirection, callbackContext) == false){
       return true;
     }
 

--- a/src/android/CameraPreview.java
+++ b/src/android/CameraPreview.java
@@ -84,6 +84,9 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     Manifest.permission.CAMERA
   };
 
+  private Camera frontCamera;
+  private Camera backCamera;
+
   private CameraActivity fragment;
   private CallbackContext takePictureCallbackContext;
   private CallbackContext takeSnapshotCallbackContext;
@@ -267,106 +270,44 @@ public class CameraPreview extends CordovaPlugin implements CameraActivity.Camer
     return true;
   }
 
+  private Camera getCamera (String direction) {
+    if (direction.equals("front")) {
+      return frontCamera;
+    }
+    else if (direction.equals("back")) {
+      return backCamera;
+    }
+  }
+
   private boolean startCamera(int x, int y, int width, int height, String defaultCamera, Boolean tapToTakePicture, Boolean dragEnabled, final Boolean toBack, String alpha, boolean tapFocus, boolean disableExifHeaderStripping, boolean storeToFile, CallbackContext callbackContext) {
     Log.d(TAG, "start camera action");
 
-    if (fragment != null) {
+    if (getCamera(defaultCamera) != null) {
       callbackContext.error("Camera already started");
+      return true;  
+    }
+  
+    Camera camera = new Camera();
+    boolean result = camera.start(
+      x, y, width, height,
+      defaultCamera,
+      tapToTakePicture, dragEnabled, toBack,
+      alpha, 
+      tapFocus, disableExifHeaderStripping, storeToFile
+    );
+
+    if (result == false) {
+      callbackContext.error("Camera could not be started");
       return true;
     }
 
-    final float opacity = Float.parseFloat(alpha);
-
-    fragment = new CameraActivity();
-    fragment.setEventListener(this);
-    fragment.defaultCamera = defaultCamera;
-    fragment.tapToTakePicture = tapToTakePicture;
-    fragment.dragEnabled = dragEnabled;
-    fragment.tapToFocus = tapFocus;
-    fragment.disableExifHeaderStripping = disableExifHeaderStripping;
-    fragment.storeToFile = storeToFile;
-    fragment.toBack = toBack;
-
-    DisplayMetrics metrics = cordova.getActivity().getResources().getDisplayMetrics();
-
-    // offset
-    int computedX = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, x, metrics);
-    int computedY = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, y, metrics);
-
-    // size
-    int computedWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, width, metrics);
-    int computedHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, height, metrics);
-
-    fragment.setRect(computedX, computedY, computedWidth, computedHeight);
-
-    startCameraCallbackContext = callbackContext;
-
-    cordova.getActivity().runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-
-        //create or update the layout params for the container view
-        FrameLayout containerView = (FrameLayout)cordova.getActivity().findViewById(containerViewId);
-        if(containerView == null){
-          containerView = new FrameLayout(cordova.getActivity().getApplicationContext());
-          containerView.setId(containerViewId);
-
-          FrameLayout.LayoutParams containerLayoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
-          cordova.getActivity().addContentView(containerView, containerLayoutParams);
-        }
-
-        //display camera below the webview
-        if(toBack){
-          View view = webView.getView();
-          ViewParent rootParent = containerView.getParent();
-          ViewParent curParent = view.getParent();
-
-          view.setBackgroundColor(0x00000000);
-
-          // If parents do not match look for.
-          if(curParent.getParent() != rootParent) {
-            while(curParent != null && curParent.getParent() != rootParent) {
-              curParent = curParent.getParent();
-            }
-
-            if(curParent != null) {
-              ((ViewGroup)curParent).setBackgroundColor(0x00000000);
-              ((ViewGroup)curParent).bringToFront();
-            } else {
-              // Do default...
-              curParent = view.getParent();
-              webViewParent = curParent;
-              ((ViewGroup)view).bringToFront();
-            }
-          }else{
-            // Default
-            webViewParent = curParent;
-            rootParent.bringChildToFront(((View) webViewParent));
-          }
-
-        }else{
-          //set camera back to front
-          containerView.setAlpha(opacity);
-          containerView.bringToFront();
-        }
-
-        //add the fragment to the container
-        FragmentManager fragmentManager = cordova.getActivity().getFragmentManager();
-        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-        fragmentTransaction.add(containerView.getId(), fragment);
-        fragmentTransaction.commit();
-      }
-    });
+    if (defaultCamera.equals("front")) {
+      frontCamera = camera;
+    } else if (defaultCamera.equals("back")) {
+      backCamera = camera;
+    }
 
     return true;
-  }
-
-  public void onCameraStarted() {
-    Log.d(TAG, "Camera started");
-
-    PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, "Camera started");
-    pluginResult.setKeepCallback(false);
-    startCameraCallbackContext.sendPluginResult(pluginResult);
   }
 
   private boolean takeSnapshot(int quality, CallbackContext callbackContext) {

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -61,7 +61,7 @@ declare module 'cordova-plugin-camera-preview' {
     show(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     takePicture(options?: CameraPreviewTakePictureOptions|CameraPreviewSuccessHandler, onSuccess?: CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?: CameraPreviewErrorHandler): void;
     takeSnapshot(options?: CameraPreviewTakeSnapshotOptions|CameraPreviewSuccessHandler, onSuccess?: CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?: CameraPreviewErrorHandler): void;
-    setColorEffect(cameraDirection?:CameraPreviewCameraDirection|string, effect: CameraPreviewColorEffect|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setColorEffect(cameraDirection:CameraPreviewCameraDirection|string, effect: CameraPreviewColorEffect|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     setZoom(cameraDirection?:CameraPreviewCameraDirection|string, zoom?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     startRecordVideo(options?:CameraPreviewStartRecordVideoOptions|CameraPreviewSuccessHandler, onSuccess?:CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?:CameraPreviewErrorHandler):void;
     stopRecordVideo(options?: CameraPreviewCameraDirectionOption|CameraPreviewSuccessHandler, onSuccess?:CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?:CameraPreviewErrorHandler):void;
@@ -73,7 +73,7 @@ declare module 'cordova-plugin-camera-preview' {
     getSupportedPictureSizes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedFlashModes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedColorEffects(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setFlashMode(cameraDirection?: CameraPreviewCameraDirection|string, flashMode: CameraPreviewFlashMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setFlashMode(cameraDirection: CameraPreviewCameraDirection|string, flashMode: CameraPreviewFlashMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedFocusModes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getFocusMode(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     setFocusMode(cameraDirection?: CameraPreviewCameraDirection|string, focusMode?: CameraPreviewFocusMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -77,4 +77,8 @@ declare module 'cordova-plugin-camera-preview' {
     getBlob(path: string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getCameraCharacteristics(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
   }
+
+  interface CameraPreviewManager {
+    createCameraPreview(): CameraPreview;
+  }
 }

--- a/typescript/CameraPreview.d.ts
+++ b/typescript/CameraPreview.d.ts
@@ -9,6 +9,10 @@ declare module 'cordova-plugin-camera-preview' {
   type CameraPreviewFocusMode = 'fixed'|'auto'|'continuous'|'continuous-picture'|'continuous-video'|'edof'|'infinity'|'macro';
   type CameraPreviewWhiteBalanceMode = 'lock'|'auto'|'continuous'|'incandescent'|'cloudy-daylight'|'daylight'|'fluorescent'|'shade'|'twilight'|'warm-fluorescent';
 
+  interface CameraPreviewCameraDirectionOption {
+    cameraDirection?: CameraPreviewCameraDirection|string;
+  }
+
   interface CameraPreviewStartCameraOptions {
     alpha?: number;
     camera?: CameraPreviewCameraDirection|string;
@@ -25,13 +29,23 @@ declare module 'cordova-plugin-camera-preview' {
   }
 
   interface CameraPreviewTakePictureOptions {
+    cameraDirection?: CameraPreviewCameraDirection|string;
     height?: number;
     quality?: number;
     width?: number;
   }
 
   interface CameraPreviewTakeSnapshotOptions {
+    cameraDirection?: CameraPreviewCameraDirection|string;
     quality?: number;
+  }
+
+  interface CameraPreviewStartRecordVideoOptions {
+    cameraDirection?: CameraPreviewCameraDirection|string;
+    width?: number;
+    height?: number;
+    quality?: number;
+    withFlash?: boolean;
   }
 
   interface CameraPreviewPreviewSizeDimension {
@@ -41,41 +55,41 @@ declare module 'cordova-plugin-camera-preview' {
 
   interface CameraPreview {
     startCamera(options?: CameraPreviewStartCameraOptions, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    stopCamera(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    switchCamera(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    hide(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    show(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    stopCamera(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    switchCamera(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    hide(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    show(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     takePicture(options?: CameraPreviewTakePictureOptions|CameraPreviewSuccessHandler, onSuccess?: CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?: CameraPreviewErrorHandler): void;
     takeSnapshot(options?: CameraPreviewTakeSnapshotOptions|CameraPreviewSuccessHandler, onSuccess?: CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?: CameraPreviewErrorHandler): void;
-    setColorEffect(effect: CameraPreviewColorEffect|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setZoom(zoom?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    startRecordVideo(options?:any|CameraPreviewSuccessHandler, onSuccess?:CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?:CameraPreviewErrorHandler):void;
-    stopRecordVideo(onSuccess?:CameraPreviewSuccessHandler, onError?:CameraPreviewErrorHandler):void;
-    getMaxZoom(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setColorEffect(cameraDirection?:CameraPreviewCameraDirection|string, effect: CameraPreviewColorEffect|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setZoom(cameraDirection?:CameraPreviewCameraDirection|string, zoom?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    startRecordVideo(options?:CameraPreviewStartRecordVideoOptions|CameraPreviewSuccessHandler, onSuccess?:CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?:CameraPreviewErrorHandler):void;
+    stopRecordVideo(options?: CameraPreviewCameraDirectionOption|CameraPreviewSuccessHandler, onSuccess?:CameraPreviewSuccessHandler|CameraPreviewErrorHandler, onError?:CameraPreviewErrorHandler):void;
+    getMaxZoom(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedFocusMode(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getZoom(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getHorizontalFOV(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setPreviewSize(dimensions?: CameraPreviewPreviewSizeDimension|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getSupportedPictureSizes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getSupportedFlashModes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getSupportedColorEffects(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setFlashMode(flashMode: CameraPreviewFlashMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getSupportedFocusModes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getFocusMode(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setFocusMode(focusMode?: CameraPreviewFocusMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    tapToFocus(xPoint?: number, yPoint?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getExposureModes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getExposureMode(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setExposureMode(exposureMode?: CameraPreviewExposureMode, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getExposureCompensation(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setExposureCompensation(exposureCompensation?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getExposureCompensationRange(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getSupportedWhiteBalanceModes(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getZoom(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getHorizontalFOV(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setPreviewSize(cameraDirection?: CameraPreviewCameraDirection|string, dimensions?: CameraPreviewPreviewSizeDimension|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getSupportedPictureSizes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getSupportedFlashModes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getSupportedColorEffects(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setFlashMode(cameraDirection?: CameraPreviewCameraDirection|string, flashMode: CameraPreviewFlashMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getSupportedFocusModes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getFocusMode(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setFocusMode(cameraDirection?: CameraPreviewCameraDirection|string, focusMode?: CameraPreviewFocusMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    tapToFocus(cameraDirection?:CameraPreviewCameraDirection|string, xPoint?: number, yPoint?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getExposureModes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getExposureMode(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setExposureMode(cameraDirection?: CameraPreviewCameraDirection|string, exposureMode?: CameraPreviewExposureMode, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getExposureCompensation(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setExposureCompensation(cameraDirection?: CameraPreviewCameraDirection|string, exposureCompensation?: number, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getExposureCompensationRange(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getSupportedWhiteBalanceModes(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getSupportedWhiteBalanceMode(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    setWhiteBalanceMode(whiteBalanceMode?: CameraPreviewWhiteBalanceMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    setWhiteBalanceMode(cameraDirection?: CameraPreviewCameraDirection|string, whiteBalanceMode?: CameraPreviewWhiteBalanceMode|string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     onBackButton(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
     getBlob(path: string, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
-    getCameraCharacteristics(onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
+    getCameraCharacteristics(options?: CameraPreviewCameraDirectionOption, onSuccess?: CameraPreviewSuccessHandler, onError?: CameraPreviewErrorHandler): void;
   }
 
   interface CameraPreviewManager {

--- a/www/CameraPreview.js
+++ b/www/CameraPreview.js
@@ -62,20 +62,64 @@ CameraPreview.startCamera = function(options, onSuccess, onError) {
   ]);
 };
 
-CameraPreview.stopCamera = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "stopCamera", []);
+CameraPreview.stopCamera = function(opts, onSuccess, onError) {
+  if (!opts) {
+    opts = {};
+  } else if (isFunction(opts)) {
+    onSuccess = opts;
+    opts = {};
+  }
+
+  if (!isFunction(onSuccess)) {
+    return false;
+  }
+
+  exec(onSuccess, onError, PLUGIN_NAME, "stopCamera", [opts.cameraDirection]);
 };
 
-CameraPreview.switchCamera = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "switchCamera", []);
+CameraPreview.switchCamera = function(opts, onSuccess, onError) {
+  if (!opts) {
+    opts = {};
+  } else if (isFunction(opts)) {
+    onSuccess = opts;
+    opts = {};
+  }
+
+  if (!isFunction(onSuccess)) {
+    return false;
+  }
+
+  exec(onSuccess, onError, PLUGIN_NAME, "switchCamera", [opts.cameraDirection]);
 };
 
-CameraPreview.hide = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "hideCamera", []);
+CameraPreview.hide = function(opts, onSuccess, onError) {
+  if (!opts) {
+    opts = {};
+  } else if (isFunction(opts)) {
+    onSuccess = opts;
+    opts = {};
+  }
+
+  if (!isFunction(onSuccess)) {
+    return false;
+  }
+
+  exec(onSuccess, onError, PLUGIN_NAME, "hideCamera", [opts.cameraDirection]);
 };
 
-CameraPreview.show = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "showCamera", []);
+CameraPreview.show = function(opts, onSuccess, onError) {
+  if (!opts) {
+    opts = {};
+  } else if (isFunction(opts)) {
+    onSuccess = opts;
+    opts = {};
+  }
+
+  if (!isFunction(onSuccess)) {
+    return false;
+  }
+
+  exec(onSuccess, onError, PLUGIN_NAME, "showCamera", [opts.cameraDirection]);
 };
 
 CameraPreview.takeSnapshot = function(opts, onSuccess, onError) {
@@ -94,7 +138,7 @@ CameraPreview.takeSnapshot = function(opts, onSuccess, onError) {
     opts.quality = 85;
   }
 
-  exec(onSuccess, onError, PLUGIN_NAME, "takeSnapshot", [opts.quality]);
+  exec(onSuccess, onError, PLUGIN_NAME, "takeSnapshot", [opts.cameraDirection, opts.quality]);
 };
 
 CameraPreview.takePicture = function(opts, onSuccess, onError) {
@@ -116,111 +160,111 @@ CameraPreview.takePicture = function(opts, onSuccess, onError) {
     opts.quality = 85;
   }
 
-  exec(onSuccess, onError, PLUGIN_NAME, "takePicture", [opts.width, opts.height, opts.quality]);
+  exec(onSuccess, onError, PLUGIN_NAME, "takePicture", [opts.cameraDirection, opts.opts.width, opts.height, opts.quality]);
 };
 
-CameraPreview.setColorEffect = function(effect, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setColorEffect", [effect]);
+CameraPreview.setColorEffect = function(cameraDirection, effect, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setColorEffect", [cameraDirection, effect]);
 };
 
-CameraPreview.setZoom = function(zoom, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setZoom", [zoom]);
+CameraPreview.setZoom = function(cameraDirection, zoom, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setZoom", [cameraDirection, zoom]);
 };
 
-CameraPreview.getMaxZoom = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getMaxZoom", []);
+CameraPreview.getMaxZoom = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getMaxZoom", [opts.cameraDirection]);
 };
 
-CameraPreview.getZoom = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getZoom", []);
+CameraPreview.getZoom = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getZoom", [opts.cameraDirection]);
 };
 
-CameraPreview.getHorizontalFOV = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getHorizontalFOV", []);
+CameraPreview.getHorizontalFOV = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getHorizontalFOV", [opts.cameraDirection]);
 };
 
-CameraPreview.setPreviewSize = function(dimensions, onSuccess, onError) {
+CameraPreview.setPreviewSize = function(cameraDirection, dimensions, onSuccess, onError) {
   dimensions = dimensions || {};
   dimensions.width = dimensions.width || window.screen.width;
   dimensions.height = dimensions.height || window.screen.height;
 
-  exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [dimensions.width, dimensions.height]);
+  exec(onSuccess, onError, PLUGIN_NAME, "setPreviewSize", [cameraDirection, dimensions.width, dimensions.height]);
 };
 
-CameraPreview.getSupportedPictureSizes = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", []);
+CameraPreview.getSupportedPictureSizes = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedPictureSizes", [opts.cameraDirection]);
 };
 
-CameraPreview.getSupportedFlashModes = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedFlashModes", []);
+CameraPreview.getSupportedFlashModes = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedFlashModes", [opts.cameraDirection]);
 };
 
-CameraPreview.getSupportedColorEffects = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedColorEffects", []);
+CameraPreview.getSupportedColorEffects = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedColorEffects", [opts.cameraDirection]);
 };
 
-CameraPreview.setFlashMode = function(flashMode, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [flashMode]);
+CameraPreview.setFlashMode = function(cameraDirection, flashMode, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setFlashMode", [cameraDirection, flashMode]);
 };
 
-CameraPreview.getFlashMode = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getFlashMode", []);
+CameraPreview.getFlashMode = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getFlashMode", [opts.cameraDirection]);
 };
 
-CameraPreview.getSupportedFocusModes = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedFocusModes", []);
+CameraPreview.getSupportedFocusModes = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedFocusModes", [opts.cameraDirection]);
 };
 
-CameraPreview.getFocusMode = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getFocusMode", []);
+CameraPreview.getFocusMode = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getFocusMode", [opts.cameraDirection]);
 };
 
-CameraPreview.setFocusMode = function(focusMode, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setFocusMode", [focusMode]);
+CameraPreview.setFocusMode = function(cameraDirection, focusMode, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setFocusMode", [cameraDirection, focusMode]);
 };
 
-CameraPreview.tapToFocus = function(xPoint, yPoint, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [xPoint, yPoint]);
+CameraPreview.tapToFocus = function(cameraDirection, xPoint, yPoint, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "tapToFocus", [cameraDirection, xPoint, yPoint]);
 };
 
-CameraPreview.getExposureModes = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getExposureModes", []);
+CameraPreview.getExposureModes = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getExposureModes", [opts.cameraDirection]);
 };
 
-CameraPreview.getExposureMode = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getExposureMode", []);
+CameraPreview.getExposureMode = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getExposureMode", [opts.cameraDirection]);
 };
 
-CameraPreview.setExposureMode = function(exposureMode, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setExposureMode", [exposureMode]);
+CameraPreview.setExposureMode = function(cameraDirection, exposureMode, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setExposureMode", [cameraDirection, exposureMode]);
 };
 
-CameraPreview.getExposureCompensation = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensation", []);
+CameraPreview.getExposureCompensation = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensation", [opts.cameraDirection]);
 };
 
-CameraPreview.setExposureCompensation = function(exposureCompensation, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setExposureCompensation", [exposureCompensation]);
+CameraPreview.setExposureCompensation = function(cameraDirection, exposureCompensation, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setExposureCompensation", [cameraDirection, exposureCompensation]);
 };
 
-CameraPreview.getExposureCompensationRange = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensationRange", []);
+CameraPreview.getExposureCompensationRange = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getExposureCompensationRange", [opts.cameraDirection]);
 };
 
-CameraPreview.getSupportedWhiteBalanceModes = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedWhiteBalanceModes", []);
+CameraPreview.getSupportedWhiteBalanceModes = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getSupportedWhiteBalanceModes", [opts.cameraDirection]);
 };
 
-CameraPreview.getWhiteBalanceMode = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getWhiteBalanceMode", []);
+CameraPreview.getWhiteBalanceMode = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getWhiteBalanceMode", [opts.cameraDirection]);
 };
 
-CameraPreview.setWhiteBalanceMode = function(whiteBalanceMode, onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "setWhiteBalanceMode", [whiteBalanceMode]);
+CameraPreview.setWhiteBalanceMode = function(cameraDirection, whiteBalanceMode, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "setWhiteBalanceMode", [cameraDirection, whiteBalanceMode]);
 };
 
-CameraPreview.getCameraCharacteristics = function(onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "getCameraCharacteristics", []);
+CameraPreview.getCameraCharacteristics = function(opts, onSuccess, onError) {
+  exec(onSuccess, onError, PLUGIN_NAME, "getCameraCharacteristics", [opts.cameraDirection]);
 };
 
 CameraPreview.onBackButton = function(onSuccess, onError) {
@@ -273,8 +317,19 @@ CameraPreview.startRecordVideo = function (opts, onSuccess, onError) {
   exec(onSuccess, onError, PLUGIN_NAME, "startRecordVideo", [opts.cameraDirection, opts.width, opts.height, opts.quality, opts.withFlash]);
 };
 
-CameraPreview.stopRecordVideo = function (onSuccess, onError) {
-  exec(onSuccess, onError, PLUGIN_NAME, "stopRecordVideo");
+CameraPreview.stopRecordVideo = function (opts, onSuccess, onError) {
+  if (!opts) {
+    opts = {};
+  } else if (isFunction(opts)) {
+    onSuccess = opts;
+    opts = {};
+  }
+
+  if (!isFunction(onSuccess)) {
+    return false;
+  }
+
+  exec(onSuccess, onError, PLUGIN_NAME, "stopRecordVideo", [opts.cameraDirection]);
 };
 
 CameraPreview.FOCUS_MODE = {


### PR DESCRIPTION
Add feature to support open front and back camera simultaneously.

Refactor class CameraPreview, and moving camera functions to new class Camera, in order to achieve creating multiple CameraActivity instance.

Function will be refactor:
- [x] hasView
- [x] hasCamera
- [x] startCamera
- [x] onCameraStarted
- [x] startRecordVideo
- [x] onStartRecordVideo
- [x] stopRecordVideo
- [x] onStopRecordVideo
- [x] onStopRecordVideoError
- [ ] onRequestPermissionResult
- [ ] getSupportedPictureSizes
- [ ] takeSnapshot
- [ ] onSnapshotTaken
- [ ] onSnapshotTakenError
- [ ] takePicture
- [ ] onPictureTaken
- [ ] onPictureTakenError
- [ ] onStartRecordVideoError
- [ ] setColorEffect
- [ ] getSupportedColorEffects
- [ ] getExposureModes
- [ ] getExposureMode
- [ ] setExposureMode
- [ ] getExposureCompensation
- [ ] setExposureCompensation
- [ ] getExposureCompensationRange
- [ ] getSupportedWhiteBalanceModes
- [ ] getWhiteBalanceMode
- [ ] setWhiteBalanceMode
- [ ] getMaxZoom
- [ ] getHorizontalFOV
- [ ] getZoom
- [ ] setZoom
- [ ] setPreviewSize
- [ ] getSupportedFlashModes
- [ ] getSupportedFocusModes
- [ ] getFocusMode
- [ ] setFocusMode
- [ ] getFlashMode
- [ ] setFlashMode
- [ ] stopCamera
- [ ] showCamera
- [ ] hideCamera
- [ ] tapToFocus
- [ ] onFocusSet
- [ ] onFocusSetError
- [ ] switchCamera